### PR TITLE
Prevent packer from connecting to installer SSH

### DIFF
--- a/http/user-data
+++ b/http/user-data
@@ -1,6 +1,8 @@
 #cloud-config
 autoinstall:
   version: 1
+  early-commands:
+    - systemctl stop ssh
   identity:
     hostname: ubuntu-server
     password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'

--- a/ubuntu-2004.json
+++ b/ubuntu-2004.json
@@ -11,7 +11,7 @@
 
       "ssh_username": "ubuntu",
       "ssh_password": "ubuntu",
-      "ssh_handshake_attempts": "20",
+      "ssh_timeout": "30m",
 
       "http_directory": "http",
 


### PR DESCRIPTION
Disable the ssh server immediately after the installer starts to prevent packer from connecting to the wrong SSH server.

By doing this, increasing handshake attempts is no longer needed. Instead, the SSH timeout should be increased to allow for longer boot time in case a lot of packages are installed.